### PR TITLE
Fix EULA colors for dark theme

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 -   Issue with horizontal scrolling when using HTML EULA on Android ([#113](https://github.com/brightlayer-ui/react-native-workflows/issues/113)).
+-   Issue with background colors when using HTML EULA with the dark theme.
 
 ## v4.0.0 (December 9, 2021)
 

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-native-auth-workflow",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-    "version": "4.1.0-beta.0",
+    "version": "4.1.0-beta.1",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/login-workflow/src/subScreens/Eula.tsx
+++ b/login-workflow/src/subScreens/Eula.tsx
@@ -91,7 +91,7 @@ export const Eula: React.FC<EulaProps> = (props) => {
         ? props.eulaContent ?? props.eulaError ?? t('blui:REGISTRATION.EULA.LOADING')
         : props.eulaContent ??
           '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>' +
-              '<style>body { font-size: 120%; word-wrap: break-word; overflow-wrap: break-word; }</style>' +
+              `<style>html, body { font-size: 120%; word-wrap: break-word; overflow-wrap: break-word; margin: 0; padding: 0; color: ${theme.colors.text}; background-color: ${theme.colors.surface}; }</style>` +
               `<body>${props.eulaError ?? t('blui:REGISTRATION.EULA.LOADING')}</body>` +
               '</html>';
 
@@ -106,10 +106,14 @@ export const Eula: React.FC<EulaProps> = (props) => {
                     {htmlEula ? (
                         <WebView
                             originWhitelist={['*']}
-                            source={{ html: eulaContentInternals }}
+                            source={{ html: eulaContentInternals, baseUrl: '' }}
                             scalesPageToFit={false}
                             onLoadEnd={onLoadEnd}
-                            style={{ flex: 1, height: 50 /* WebView needs a fixed height set or it won't render */ }}
+                            style={{
+                                flex: 1,
+                                height: 50 /* WebView needs a fixed height set or it won't render */,
+                                backgroundColor: theme.colors.surface,
+                            }}
                         />
                     ) : (
                         <ScrollView>

--- a/login-workflow/src/subScreens/Eula.tsx
+++ b/login-workflow/src/subScreens/Eula.tsx
@@ -91,7 +91,7 @@ export const Eula: React.FC<EulaProps> = (props) => {
         ? props.eulaContent ?? props.eulaError ?? t('blui:REGISTRATION.EULA.LOADING')
         : props.eulaContent ??
           '<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0"></head>' +
-              `<style>html, body { font-size: 120%; word-wrap: break-word; overflow-wrap: break-word; margin: 0; padding: 0; color: ${theme.colors.text}; background-color: ${theme.colors.surface}; }</style>` +
+              `<style>body { font-size: 120%; word-wrap: break-word; overflow-wrap: break-word; margin: 0; padding: 0; color: ${theme.colors.text}; background-color: ${theme.colors.surface}; }</style>` +
               `<body>${props.eulaError ?? t('blui:REGISTRATION.EULA.LOADING')}</body>` +
               '</html>';
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes an issue reported by CRDS team. The loading EULA screen uses light theme even if the application is set to dark theme.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Set the background and font colors based on the theme
- Remove some default margin/padding

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

Before:
<img src="https://user-images.githubusercontent.com/29152776/151985227-e5ac606b-086b-4342-afae-68c14b3c8072.png" width="200px" height="auto"/>

After:
<img src="https://user-images.githubusercontent.com/29152776/151987516-8de58925-51a4-4973-baff-06ec82218790.png" width="200px" height="auto"/>
<img src="https://user-images.githubusercontent.com/29152776/151987317-e16ad63e-7867-4f27-8fb7-65ab35cba453.png" width="200px" height="auto"/>



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Open the example project
- In App.tsx, set htmlEula to true on the AuthUIContextProvider
- On the App component, set the theme to BLUITemes.blueDark
- In the loadEula function in RegistrationUIActions.tsx, make sure you are returning an HTML string for the EULA. You can use this as an example:

```tsx
export const SAMPLE_EULA_HTML = `
<style>
    html, body{
        margin: 0;
        padding: 0;
        background: #1d2529;
    }
    .eulaWraper {
        background: #1d2529;
        font-family: 'Open Sans';
        font-family: 'OpenSans-Regular';
        word-wrap: break-word;
    }
    .eulaWraper p,
    .eulaWraper ul li {
        color: #eef0f0;
        line-height: 1.2;
    }

    .eulaWraper p a {
        color: #80bde0;
    }
</style>
<div class="eulaWraper">
    <p>
        Eaton Corporation (“<strong>EATON</strong>”) owns and operates the <strong>-Smart breakers and EV smart breaker
            chargers</strong> product software (“<strong>Product Software</strong>”). The following <strong>Smart
            breakers/
            EV smart breaker chargers</strong>
        End-User License Agreement (“<strong>Agreement</strong>”) governs the use of this Product Software. Other sites,
        content or online services owned or controlled by Eaton have their own terms of use/end-user license agreement
        and
        should be reviewed. Eaton licenses the use of the Product Software to you subject to the terms of this
        Agreement.
    </p>
</div>
`;
```

- Open the App and click on the Register Now button...observe that the loading screen and the EULA look correct with both dark theme and light theme applied.
