### PR TITLE
Fix empty code validation screen opened from link

### DIFF
--- a/login-workflow/example/ios/example/AppDelegate.m
+++ b/login-workflow/example/ios/example/AppDelegate.m
@@ -3,6 +3,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
 
 #if RCT_DEV
 #import <React/RCTDevLoadingView.h>
@@ -61,6 +62,21 @@ static void InitializeFlipper(UIApplication *application) {
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
+}
+
+- (BOOL)application:(UIApplication *)application
+   openURL:(NSURL *)url
+   options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
+{
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity
+ restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler
+{
+ return [RCTLinkingManager application:application
+                  continueUserActivity:userActivity
+                    restorationHandler:restorationHandler];
 }
 
 @end

--- a/login-workflow/example/ios/example/Info.plist
+++ b/login-workflow/example/ios/example/Info.plist
@@ -20,6 +20,19 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>authui</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>authui</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
@@ -36,21 +49,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>OpenSans-Bold.ttf</string>
@@ -76,5 +75,19 @@
 		<string>Zocial.ttf</string>
 		<string>BrightlayerUIIcons.ttf</string>
 	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -275,16 +275,17 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'VerifyEmail',
             pageTitle: t('blui:REGISTRATION.STEPS.VERIFY_EMAIL'),
             pageBody: (
-                <VerifyEmailScreen
-                    key={'VerifyEmailPage'}
-                    initialCode={verificationCode}
-                    onVerifyCodeChanged={setVerificationCode}
-                    onResendVerificationEmail={(): void => {
-                        void requestCode();
-                    }}
-                    /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                    onSubmit={(): void => advancePage(1)}
-                />
+                <View key={'VerifyEmailPage'} style={{ width: '100%', maxWidth: 600 }}>
+                    <VerifyEmailScreen
+                        initialCode={verificationCode}
+                        onVerifyCodeChanged={setVerificationCode}
+                        onResendVerificationEmail={(): void => {
+                            void requestCode();
+                        }}
+                        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                        onSubmit={(): void => advancePage(1)}
+                    />
+                </View>
             ),
             canGoForward: verificationCode.length > 0,
             canGoBack: true,

--- a/login-workflow/src/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/subScreens/VerifyEmail.tsx
@@ -72,7 +72,7 @@ const makeStyles = (): Record<string, any> =>
  */
 type VerifyEmailProps = {
     initialCode?: string;
-    onVerifyCodeChanged(email: string): void;
+    onVerifyCodeChanged(code: string): void;
     onResendVerificationEmail(): void;
     onSubmit?: () => void;
     theme?: ReactNativePaper.Theme;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #118 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- All PagerViews should be wrapped in a plain View and not use flex. As the others are fine at the moment, only the VerifyEmail screen was wrapped.
- Added some methods to App Delegate to allow deeplinks to work

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- React Native Pager view is broken. You might need to test with the branch from this [PR](https://github.com/callstack/react-native-pager-view/pull/520)
- Deeplink command test from terminal when running in iOS sim. `xcrun simctl openurl booted "authui://register/696512?email=test%40domain.com"`
