### PR TITLE
Fill eula and email on deeplink and wrap pages in views

### DIFF
--- a/login-workflow/src/__tests__/subscreens/CreateAccount-test.tsx
+++ b/login-workflow/src/__tests__/subscreens/CreateAccount-test.tsx
@@ -26,7 +26,7 @@ describe('CreateAccount subScreen tested with enzyme', () => {
             /* do nothing */
         }
     ): JSX.Element {
-        return <CreateAccount onEmailChanged={onEmailChanged} />;
+        return <CreateAccount onEmailChanged={onEmailChanged} initialEmail={''} />;
     }
 
     it('renders correctly', () => {

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -223,8 +223,8 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
         }
     };
 
-    const onEmailChanged = useCallback((email: string) => {
-        setEmail(email); 
+    const onEmailChanged = useCallback((changedEmail: string) => {
+        setEmail(changedEmail);
         setVerificationCode('');
     }, []);
 

--- a/login-workflow/src/subScreens/CreateAccount.tsx
+++ b/login-workflow/src/subScreens/CreateAccount.tsx
@@ -65,6 +65,7 @@ const makeStyles = (): Record<string, any> =>
  * @param theme (Optional) react-native-paper theme partial for custom styling.
  */
 type CreateAccountProps = {
+    initialEmail: string;
     onEmailChanged(email: string): void;
     onSubmit?: () => void;
     theme?: ReactNativePaper.Theme;
@@ -77,7 +78,7 @@ type CreateAccountProps = {
  */
 export const CreateAccount: React.FC<CreateAccountProps> = (props) => {
     const theme = useTheme(props.theme);
-    const [emailInput, setEmailInput] = React.useState('');
+    const [emailInput, setEmailInput] = React.useState(props.initialEmail ?? '');
     const [hasEmailFormatError, setHasEmailFormatError] = React.useState(false);
     const { t } = useLanguageLocale();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- When coming from a deep link to self-registration, EULA should be already accepted and the email should be entered in case the user goes back.
- Wrap PagerView views in an empty view (no flex) to avoid over-optimization (resulting in "blank" pages).

React-Native-Pager-View might have to be changed to `https://github.com/Shiverware/react-native-pager-view.git` in order to fix some of the issues in the current pager release.
