### PR TITLE
Update resend verification code button styles

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v4.2.0 (unreleased)
+
+### Changed
+
+-   Changed the verification code styles for the self registration workflow ([#157](https://github.com/brightlayer-ui/react-native-workflows/issues/157)).
+
 ## v4.1.0 (April 28, 2022)
 
 ### Fixes

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -421,11 +421,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: a28897a626e417fac264bb26dd72ad0e9af5bfa8
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
+  glog: 19d4e11abe55266cf98e1e24f94a850a44fdec35
+  RCT-Folly: fa983ee666a7087ebbb1489b453d69cac3581786
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
   React: 98eac01574128a790f0bbbafe2d1a8607291ac24

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -423,7 +423,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: ca69556b2147503eadb94ee25ccbcb9c631ad761
+  FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a

--- a/login-workflow/example/package.json
+++ b/login-workflow/example/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@brightlayer-ui/colors": "^3.0.1",
         "@brightlayer-ui/icons-svg": "^1.7.0",
-        "@brightlayer-ui/react-native-auth-workflow": "^4.0.0-beta.0",
+        "@brightlayer-ui/react-native-auth-workflow": "^4.1.0",
         "@brightlayer-ui/react-native-components": "^6.0.1",
         "@brightlayer-ui/react-native-vector-icons": "^1.3.1",
         "@brightlayer-ui/react-native-themes": "^6.0.0",

--- a/login-workflow/example/yarn.lock
+++ b/login-workflow/example/yarn.lock
@@ -744,17 +744,17 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-auth-shared@^3.4.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.5.0.tgz#218c26fde35c41fd691bf3730234c06233f735d6"
-  integrity sha512-rMImuIZ10CKVYpTQGfluApYeYUr/E4LBW5tLKQsduW0Bdag/Jw9UsjBwFr6o+IjXIWZYpsy26r48F5vr7KuMkQ==
+"@brightlayer-ui/react-auth-shared@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.0.tgz#7b447109452a269cf073974e48353d36bfff9ca8"
+  integrity sha512-xU+cQpmgDiGRs0ug6+7RVR8OigQSqnlbeArZ1TOTGphCIX05tq8hLB1BwDRCawgJzigeBqiBn2RX/oJroE3MDQ==
 
-"@brightlayer-ui/react-native-auth-workflow@^4.0.0-beta.0":
-  version "4.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-auth-workflow/-/react-native-auth-workflow-4.0.0-beta.0.tgz#8d47eb7cac26dc75d17696cec77906c7fec2e6fc"
-  integrity sha512-LcAruykBPgZ63ABWQRtTVAKSSVvF5Vd0Gq0u7hdkk+mFmpo0NZloRlPgEQI6lthTzZNiVuA00b1P482R4PxMdQ==
+"@brightlayer-ui/react-native-auth-workflow@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-auth-workflow/-/react-native-auth-workflow-4.1.0.tgz#62bdde09268d7696de2d486666610e06c6d36b23"
+  integrity sha512-rYi2PypmN3RQcKOnGW6Y60X0M6uSHS+tGU8F2X+Lirr2GfmPXAhs5EV24ozUVlAmiA4bEz4lgusbE7+ofCAmHQ==
   dependencies:
-    "@brightlayer-ui/react-auth-shared" "^3.4.0"
+    "@brightlayer-ui/react-auth-shared" "^3.7.0"
     lodash.clonedeep "^4.5.0"
     react-native-status-bar-height "^2.5.0"
 

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-native-auth-workflow",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-    "version": "4.1.0",
+    "version": "4.2.0-beta.0",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -57,7 +57,7 @@
         "tag-package": "npx -p @brightlayer-ui/tag blui-tag"
     },
     "dependencies": {
-        "@brightlayer-ui/react-auth-shared": "^3.7.0",
+        "@brightlayer-ui/react-auth-shared": "^3.7.1-beta.0",
         "lodash.clonedeep": "^4.5.0",
         "react-native-status-bar-height": "^2.5.0"
     },

--- a/login-workflow/src/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/subScreens/VerifyEmail.tsx
@@ -6,11 +6,11 @@
 import React, { useEffect } from 'react';
 
 // Components
-import { View, StyleSheet, SafeAreaView } from 'react-native';
+import { View, StyleSheet, SafeAreaView, TouchableOpacity } from 'react-native';
 import { TextInput } from '../components/TextInput';
 import { Instruction } from '../components/Instruction';
 import { useTheme } from 'react-native-paper';
-import { ThemedButton as Button } from '@brightlayer-ui/react-native-components/themed';
+import { Body1 } from '@brightlayer-ui/react-native-components';
 
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
@@ -122,15 +122,11 @@ export const VerifyEmail: React.FC<VerifyEmailProps> = (props) => {
                         onChangeText={setVerifyCode}
                         onSubmitEditing={verifyCode.length ? props.onSubmit : undefined}
                     />
-                    <View style={{ flex: 1 }}>
-                        <Button
-                            uppercase={false}
-                            mode={'contained'}
-                            onPress={(): void => onResendVerificationEmail()}
-                            style={styles.inputMargin}
-                        >
-                            {t('blui:SELF_REGISTRATION.VERIFY_EMAIL.RESEND')}
-                        </Button>
+                     <View style={{ flex: 1, flexDirection: 'row', marginTop: 24, alignItems: 'center' }}>
+                        <Body1>{t('blui:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION_CODE_PROMPT')}</Body1>
+                        <TouchableOpacity onPress={(): void => onResendVerificationEmail()}>
+                            <Body1 color="primary">&nbsp;{t('blui:ACTIONS.RESEND')}</Body1>
+                        </TouchableOpacity>
                     </View>
                 </View>
             </KeyboardAwareScrollView>

--- a/login-workflow/src/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/subScreens/VerifyEmail.tsx
@@ -122,7 +122,7 @@ export const VerifyEmail: React.FC<VerifyEmailProps> = (props) => {
                         onChangeText={setVerifyCode}
                         onSubmitEditing={verifyCode.length ? props.onSubmit : undefined}
                     />
-                     <View style={{ flex: 1, flexDirection: 'row', marginTop: 24, alignItems: 'center' }}>
+                    <View style={{ flex: 1, flexDirection: 'row', marginTop: 24, alignItems: 'center' }}>
                         <Body1>{t('blui:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION_CODE_PROMPT')}</Body1>
                         <TouchableOpacity onPress={(): void => onResendVerificationEmail()}>
                             <Body1 color="primary">&nbsp;{t('blui:ACTIONS.RESEND')}</Body1>

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1086,10 +1086,10 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-auth-shared@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.0.tgz#7b447109452a269cf073974e48353d36bfff9ca8"
-  integrity sha512-xU+cQpmgDiGRs0ug6+7RVR8OigQSqnlbeArZ1TOTGphCIX05tq8hLB1BwDRCawgJzigeBqiBn2RX/oJroE3MDQ==
+"@brightlayer-ui/react-auth-shared@^3.7.1-beta.0":
+  version "3.7.1-beta.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.1-beta.0.tgz#d626955de2d5690807356a56eba91cf174a8448b"
+  integrity sha512-YV5pxkSr6Wlh6mx6Jr+hXFvUSMGnRi27OrCOdIvaxztQhMx9mFG6BA9zx+VAMOchJAkONZFP+QpEnfUkeurnHg==
 
 "@brightlayer-ui/react-native-components@^6.0.1":
   version "6.0.1"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
BLUI-3269
Fixes #157 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Verification code button style update

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Clone react-native-workflow project
- Initialize react-auth-shared submodule using branch `feature/3269-add-verification-code-prompt-translation-text`
- `yarn start:example`
- Go to self registration workflow (click debug button, then click self-registration button)
- Navigate to the third screen in the workflow to visit the verification code page
- Observe the updated view
