### PR TITLE
BLUI-3220 MobileStepper and PasswordRequirement dark theme not showing proper active/valid state color

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v4.2.0 (unreleased)
+## v4.2.0 (Unreleased)
 
 ### Changed
 
 -   Changed the verification code styles for the self registration workflow ([#157](https://github.com/brightlayer-ui/react-native-workflows/issues/157)).
+
+### Fixes
+
+-   Issue with `<MobileStepper>` and `<RequirementCheck>` active/valid state color in dark theme ([#161](https://github.com/brightlayer-ui/react-native-workflows/issues/161)).
 
 ## v4.1.0 (April 28, 2022)
 

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -421,11 +421,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: a28897a626e417fac264bb26dd72ad0e9af5bfa8
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
-  glog: 19d4e11abe55266cf98e1e24f94a850a44fdec35
-  RCT-Folly: fa983ee666a7087ebbb1489b453d69cac3581786
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
   React: 98eac01574128a790f0bbbafe2d1a8607291ac24

--- a/login-workflow/example/package.json
+++ b/login-workflow/example/package.json
@@ -18,7 +18,7 @@
         "@brightlayer-ui/colors": "^3.0.1",
         "@brightlayer-ui/icons-svg": "^1.7.0",
         "@brightlayer-ui/react-native-auth-workflow": "^4.1.0",
-        "@brightlayer-ui/react-native-components": "^6.0.1",
+        "@brightlayer-ui/react-native-components": "^6.0.3-beta.0",
         "@brightlayer-ui/react-native-vector-icons": "^1.3.1",
         "@brightlayer-ui/react-native-themes": "^6.0.0",
         "@react-native-async-storage/async-storage": "^1.14.1",

--- a/login-workflow/example/yarn.lock
+++ b/login-workflow/example/yarn.lock
@@ -758,10 +758,10 @@
     lodash.clonedeep "^4.5.0"
     react-native-status-bar-height "^2.5.0"
 
-"@brightlayer-ui/react-native-components@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-6.0.1.tgz#8143bc7dc01045a68be5e293db9f3ae8276e48e6"
-  integrity sha512-h3Rfbw+d9465jQIbnB4NWs2oquqL0p7Xip6MxlWFPcAcEkV6aCIh1HCExNokIkLVyoRk2Nqr5QfUGfQQId1Fng==
+"@brightlayer-ui/react-native-components@^6.0.3-beta.0":
+  version "6.0.3-beta.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-6.0.3-beta.0.tgz#73ea28ee97b9b51dabcefc7f881a3b3c23ccfdaf"
+  integrity sha512-Q2ewKw1qo8kLD6I0zacMHPVDzbRvQv7YA/PXPpPzPp6rt3w1MqaIKmz0Iw2BKxhDSkmAmnclnzTAhZXqtePs2w==
   dependencies:
     "@brightlayer-ui/colors" "^3.0.0"
     color "^3.1.2"

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "@brightlayer-ui/colors": "^3.0.1",
-        "@brightlayer-ui/react-native-components": "^6.0.1",
+        "@brightlayer-ui/react-native-components": "^6.0.3-beta.0",
         "@brightlayer-ui/react-native-vector-icons": "^1.3.0",
         "@react-navigation/native": "^5.1.1",
         "@react-navigation/stack": "^5.2.3",
@@ -84,7 +84,7 @@
         "@brightlayer-ui/colors": "^3.0.0",
         "@brightlayer-ui/eslint-config": "^2.0.4",
         "@brightlayer-ui/prettier-config": "^1.0.2",
-        "@brightlayer-ui/react-native-components": "^6.0.1",
+        "@brightlayer-ui/react-native-components": "^6.0.3-beta.0",
         "@brightlayer-ui/react-native-themes": "^6.0.0",
         "@brightlayer-ui/react-native-vector-icons": "^1.3.0",
         "@react-native-async-storage/async-storage": "^1.14.1",

--- a/login-workflow/src/components/RequirementCheck.tsx
+++ b/login-workflow/src/components/RequirementCheck.tsx
@@ -51,11 +51,7 @@ export const RequirementCheck: React.FC<RequirementCheckProps> = (props) => {
     const styles = makeStyles();
 
     function colorIfValid(valid: boolean): string {
-        if (theme.dark)
-            return valid
-                ? (theme.dark ? theme.colors.actionPalette.active : theme.colors.primary) || theme.colors.primary
-                : Colors.black[500];
-        return valid ? theme.colors.primary : Colors.gray[200];
+        return valid ? theme.colors.primary : theme.dark ? Colors.black[500] : Colors.gray[200];
     }
 
     return (

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -521,9 +521,7 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
                     styles={{ root: [containerStyles.topBorder, { flex: 0 }] }}
                     steps={RegistrationPages.length}
                     activeStep={currentPage}
-                    activeColor={
-                        (theme.dark ? theme.colors.actionPalette.active : theme.colors.primary) || theme.colors.primary
-                    }
+                    activeColor={theme.colors.primary}
                     leftButton={
                         isFirstStep ? (
                             <Spacer flex={0} width={100} />

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -645,9 +645,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                     styles={{ root: [{ flex: 0 }] }}
                     steps={RegistrationPages.length}
                     activeStep={currentPage}
-                    activeColor={
-                        (theme.dark ? theme.colors.actionPalette.active : theme.colors.primary) || theme.colors.primary
-                    }
+                    activeColor={theme.colors.primary}
                     leftButton={
                         isFirstStep ? (
                             <Spacer flex={0} width={100} />

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1091,10 +1091,10 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.1-beta.0.tgz#d626955de2d5690807356a56eba91cf174a8448b"
   integrity sha512-YV5pxkSr6Wlh6mx6Jr+hXFvUSMGnRi27OrCOdIvaxztQhMx9mFG6BA9zx+VAMOchJAkONZFP+QpEnfUkeurnHg==
 
-"@brightlayer-ui/react-native-components@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-6.0.1.tgz#8143bc7dc01045a68be5e293db9f3ae8276e48e6"
-  integrity sha512-h3Rfbw+d9465jQIbnB4NWs2oquqL0p7Xip6MxlWFPcAcEkV6aCIh1HCExNokIkLVyoRk2Nqr5QfUGfQQId1Fng==
+"@brightlayer-ui/react-native-components@^6.0.3-beta.0":
+  version "6.0.3-beta.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-6.0.3-beta.0.tgz#73ea28ee97b9b51dabcefc7f881a3b3c23ccfdaf"
+  integrity sha512-Q2ewKw1qo8kLD6I0zacMHPVDzbRvQv7YA/PXPpPzPp6rt3w1MqaIKmz0Iw2BKxhDSkmAmnclnzTAhZXqtePs2w==
   dependencies:
     "@brightlayer-ui/colors" "^3.0.0"
     color "^3.1.2"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #161 / BLUI-3220 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use proper colors for MobileStepper and RequirementCheck active/valid state when using dark theme

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
Left: Before | Right: After
<img width="948" alt="Screen Shot 2022-07-14 at 3 15 29 PM" src="https://user-images.githubusercontent.com/13989985/179065099-c3448391-1799-483c-8002-ee4f44b7b8a8.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `git clone git@github.com:brightlayer-ui/react-native-workflows.git`
- `git checkout feature/BLUI-3220-mobile-stepper-pw-dark-theme-bug`
- update `example/App.tsx` line 262 to use the dark theme `{BLUIThemes.blueDark}`
- yarn start:example
- go to create account
- observe dot stepper showing the active state of which screen you are on
- step through to create password
- update password accordingly and observe the PasswordRequirements are being checked off with the proper color
