### PR TITLE
BLUI-2778 add username login functionality

### DIFF
--- a/login-workflow/example/App.tsx
+++ b/login-workflow/example/App.tsx
@@ -80,6 +80,7 @@ export const AuthUIConfiguration: React.FC = (props) => {
                     component: CustomAccountDetailsTwo,
                 },
             ]}
+            // loginType={'username'}
             // disablePagerAnimation={true}
             // registrationConfig={{
             //     firstName: {

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -421,11 +421,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: a28897a626e417fac264bb26dd72ad0e9af5bfa8
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
-  glog: 19d4e11abe55266cf98e1e24f94a850a44fdec35
-  RCT-Folly: fa983ee666a7087ebbb1489b453d69cac3581786
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
   React: 98eac01574128a790f0bbbafe2d1a8607291ac24

--- a/login-workflow/example/package.json
+++ b/login-workflow/example/package.json
@@ -18,7 +18,7 @@
         "@brightlayer-ui/colors": "^3.0.1",
         "@brightlayer-ui/icons-svg": "^1.7.0",
         "@brightlayer-ui/react-native-auth-workflow": "^4.1.0",
-        "@brightlayer-ui/react-native-components": "^6.0.1",
+        "@brightlayer-ui/react-native-components": "^6.0.3",
         "@brightlayer-ui/react-native-vector-icons": "^1.3.1",
         "@brightlayer-ui/react-native-themes": "^6.0.0",
         "@react-native-async-storage/async-storage": "^1.14.1",

--- a/login-workflow/example/yarn.lock
+++ b/login-workflow/example/yarn.lock
@@ -758,10 +758,10 @@
     lodash.clonedeep "^4.5.0"
     react-native-status-bar-height "^2.5.0"
 
-"@brightlayer-ui/react-native-components@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-6.0.1.tgz#8143bc7dc01045a68be5e293db9f3ae8276e48e6"
-  integrity sha512-h3Rfbw+d9465jQIbnB4NWs2oquqL0p7Xip6MxlWFPcAcEkV6aCIh1HCExNokIkLVyoRk2Nqr5QfUGfQQId1Fng==
+"@brightlayer-ui/react-native-components@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-6.0.3.tgz#fcf8aa5c380d81041aeccc93e0d84a915452ba71"
+  integrity sha512-ZRsoOnDLn5E+ZejG3OXzMv+YFG1pfBcq5sLkTSQvfL9Vnv5Co4o/QIYFPjztNt46RaUCRk20+4cqhrO5IVPsBA==
   dependencies:
     "@brightlayer-ui/colors" "^3.0.0"
     color "^3.1.2"

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -57,13 +57,13 @@
         "tag-package": "npx -p @brightlayer-ui/tag blui-tag"
     },
     "dependencies": {
-        "@brightlayer-ui/react-auth-shared": "^3.7.1-beta.0",
+        "@brightlayer-ui/react-auth-shared": "^3.7.1",
         "lodash.clonedeep": "^4.5.0",
         "react-native-status-bar-height": "^2.5.0"
     },
     "peerDependencies": {
         "@brightlayer-ui/colors": "^3.0.1",
-        "@brightlayer-ui/react-native-components": "^6.0.1",
+        "@brightlayer-ui/react-native-components": "^6.0.3",
         "@brightlayer-ui/react-native-vector-icons": "^1.3.0",
         "@react-navigation/native": "^5.1.1",
         "@react-navigation/stack": "^5.2.3",
@@ -84,7 +84,7 @@
         "@brightlayer-ui/colors": "^3.0.0",
         "@brightlayer-ui/eslint-config": "^2.0.4",
         "@brightlayer-ui/prettier-config": "^1.0.2",
-        "@brightlayer-ui/react-native-components": "^6.0.1",
+        "@brightlayer-ui/react-native-components": "^6.0.3",
         "@brightlayer-ui/react-native-themes": "^6.0.0",
         "@brightlayer-ui/react-native-vector-icons": "^1.3.0",
         "@react-native-async-storage/async-storage": "^1.14.1",

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -32,6 +32,7 @@ import { useNavigation } from '@react-navigation/native';
 import {
     // Constants
     EMAIL_REGEX,
+    USERNAME_REGEX,
     // Hooks
     useLanguageLocale,
     useAccountUIActions,
@@ -152,6 +153,7 @@ export const Login: React.FC<LoginProps> = (props) => {
         showRememberMe ? securityState.rememberMeDetails.email ?? '' : ''
     );
     const [hasEmailFormatError, setHasEmailFormatError] = React.useState(false);
+    const [hasUsernameFormatError, setHasUsernameFormatError] = React.useState(false);
     const [passwordInput, setPasswordInput] = React.useState('');
     const [hasAcknowledgedError, setHasAcknowledgedError] = React.useState(false);
     const [debugMode, setDebugMode] = React.useState(false);
@@ -351,6 +353,7 @@ export const Login: React.FC<LoginProps> = (props) => {
                             onChangeText={(text: string): void => {
                                 setEmailInput(text);
                                 setHasEmailFormatError(false);
+                                setHasUsernameFormatError(false);
                                 if (authUIState.login.transitErrorMessage !== null)
                                     authUIActions.dispatch(AccountActions.resetLogin());
                             }}
@@ -359,17 +362,25 @@ export const Login: React.FC<LoginProps> = (props) => {
                             }}
                             blurOnSubmit={false}
                             returnKeyType={'next'}
-                            error={isInvalidCredentials || hasEmailFormatError}
+                            error={isInvalidCredentials || hasEmailFormatError || hasUsernameFormatError}
                             errorText={
                                 isInvalidCredentials
                                     ? t('blui:LOGIN.INCORRECT_CREDENTIALS')
                                     : hasEmailFormatError
                                     ? t('blui:MESSAGES.EMAIL_ENTRY_ERROR')
+                                    : hasUsernameFormatError
+                                    ? t('blui:MESSAGES.USERNAME_ENTRY_ERROR')
                                     : ''
                             }
                             onBlur={(): void => {
-                                if (loginType === 'email' && emailInput.length > 0 && !EMAIL_REGEX.test(emailInput))
+                                if (loginType === 'email' && emailInput.length > 0 && !EMAIL_REGEX.test(emailInput)) {
                                     setHasEmailFormatError(true);
+                                } else if (
+                                    loginType === 'username' &&
+                                    emailInput.length > 0 &&
+                                    !USERNAME_REGEX.test(emailInput)
+                                )
+                                    setHasUsernameFormatError(true);
                             }}
                         />
                         <TextInputSecure
@@ -387,7 +398,11 @@ export const Login: React.FC<LoginProps> = (props) => {
                             style={{ marginTop: 44 }}
                             error={isInvalidCredentials}
                             errorText={t('blui:LOGIN.INCORRECT_CREDENTIALS')}
-                            onSubmitEditing={!EMAIL_REGEX.test(emailInput) || !passwordInput ? undefined : loginTapped}
+                            onSubmitEditing={
+                                !EMAIL_REGEX.test(emailInput) || !USERNAME_REGEX.test(emailInput) || !passwordInput
+                                    ? undefined
+                                    : loginTapped
+                            }
                         />
 
                         <View style={[containerStyles.loginControls]}>
@@ -406,6 +421,8 @@ export const Login: React.FC<LoginProps> = (props) => {
                                         disabled={
                                             loginType === 'email'
                                                 ? !EMAIL_REGEX.test(emailInput) || !passwordInput
+                                                : loginType === 'username'
+                                                ? !USERNAME_REGEX.test(emailInput) || !passwordInput
                                                 : !emailInput || !passwordInput
                                         }
                                         onPress={loginTapped}

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -128,6 +128,7 @@ export const Login: React.FC<LoginProps> = (props) => {
         showContactSupport = true,
         showRememberMe = true,
         enableResetPassword = true,
+        loginType = 'email',
         loginActions,
         loginFooter,
         loginHeader,
@@ -343,9 +344,9 @@ export const Login: React.FC<LoginProps> = (props) => {
                     <View style={[{ flexGrow: 1, maxWidth: 600 }]}>
                         <TextInput
                             testID={'email-text-field'}
-                            label={t('blui:LABELS.EMAIL')}
+                            label={loginType === 'email' ? t('blui:LABELS.EMAIL') : t('blui:LABELS.USERNAME')}
                             value={emailInput}
-                            keyboardType={'email-address'}
+                            keyboardType={loginType === 'email' ? 'email-address' : 'default'}
                             style={{ marginTop: 48 }}
                             onChangeText={(text: string): void => {
                                 setEmailInput(text);
@@ -367,7 +368,7 @@ export const Login: React.FC<LoginProps> = (props) => {
                                     : ''
                             }
                             onBlur={(): void => {
-                                if (emailInput.length > 0 && !EMAIL_REGEX.test(emailInput))
+                                if (loginType === 'email' && emailInput.length > 0 && !EMAIL_REGEX.test(emailInput))
                                     setHasEmailFormatError(true);
                             }}
                         />
@@ -402,7 +403,11 @@ export const Login: React.FC<LoginProps> = (props) => {
                                 <View style={[containerStyles.loginButtonContainer]}>
                                     <ToggleButton
                                         text={t('blui:ACTIONS.LOG_IN')}
-                                        disabled={!EMAIL_REGEX.test(emailInput) || !passwordInput}
+                                        disabled={
+                                            loginType === 'email'
+                                                ? !EMAIL_REGEX.test(emailInput) || !passwordInput
+                                                : !emailInput || !passwordInput
+                                        }
                                         onPress={loginTapped}
                                     />
                                 </View>

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1086,15 +1086,15 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-auth-shared@^3.7.1-beta.0":
-  version "3.7.1-beta.0"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.1-beta.0.tgz#d626955de2d5690807356a56eba91cf174a8448b"
-  integrity sha512-YV5pxkSr6Wlh6mx6Jr+hXFvUSMGnRi27OrCOdIvaxztQhMx9mFG6BA9zx+VAMOchJAkONZFP+QpEnfUkeurnHg==
+"@brightlayer-ui/react-auth-shared@^3.7.1":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.1.tgz#e8ee16f592a4225f9ef9de2f8741bdc941f9cf55"
+  integrity sha512-Kmvmj2pPTTp1v1TE38ZmrTtGhQcnEeY+7pnU/fE39A1dzNTn3nX5ZWGrysfoDU5c33lvWbJIsss7PUCaOKZ3nA==
 
-"@brightlayer-ui/react-native-components@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-6.0.1.tgz#8143bc7dc01045a68be5e293db9f3ae8276e48e6"
-  integrity sha512-h3Rfbw+d9465jQIbnB4NWs2oquqL0p7Xip6MxlWFPcAcEkV6aCIh1HCExNokIkLVyoRk2Nqr5QfUGfQQId1Fng==
+"@brightlayer-ui/react-native-components@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-components/-/react-native-components-6.0.3.tgz#fcf8aa5c380d81041aeccc93e0d84a915452ba71"
+  integrity sha512-ZRsoOnDLn5E+ZejG3OXzMv+YFG1pfBcq5sLkTSQvfL9Vnv5Co4o/QIYFPjztNt46RaUCRk20+4cqhrO5IVPsBA==
   dependencies:
     "@brightlayer-ui/colors" "^3.0.0"
     color "^3.1.2"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #112 /BLUI-2778.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- add username login functionality

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![Simulator Screen Shot - iPhone 12 - 2022-08-04 at 14 09 59](https://user-images.githubusercontent.com/13989985/182921038-b3da5a81-90a9-4083-888c-61fef440148d.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Clone RN workflows repo
- Be sure you are using the following branch for the auth-shared submodule `feature/blui-2778-add-username-regex-and-translations`
- Uncomment line 83 of the example `App.tsx` file and run `yarn start:example`
- Observe username field and make sure you can log in using it
- The default is 'email', so be sure to test the explicit case where you set it to email and the case where you provide no value for the `loginType` prop on the `AuthUIContextProvider` 
