### PR TITLE
BLUI-2966 Fix keyboard next button

### DIFF
--- a/login-workflow/example/src/screens/CustomRegistrationForm.tsx
+++ b/login-workflow/example/src/screens/CustomRegistrationForm.tsx
@@ -43,13 +43,18 @@ export const CustomAccountDetails: React.FC<AccountDetailsFormProps> = (props) =
 
     const countryRef = useRef<ReactTextInput>(null);
     const currencyRef = useRef<ReactTextInput>(null);
+    const goToCountry = (): void => countryRef?.current?.focus();
     const goToCurrency = (): void => currencyRef?.current?.focus();
 
     useEffect((): void => {
         // validation checks
         const valid = country !== '';
         onDetailsChanged({ country, currency }, valid);
-    }, [currency, country]); // Do NOT include onDetailsChanged in the dependencies array here or you will run into an infinite loop of updates
+
+        if (props.shouldFocusFirstCustomInput) {
+            goToCountry();
+        }
+    }, [currency, country, props.shouldFocusFirstCustomInput]); // Do NOT include onDetailsChanged in the dependencies array here or you will run into an infinite loop of updates
 
     return (
         <View style={[containerStyles.mainContainer]}>

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -57,7 +57,7 @@
         "tag-package": "npx -p @brightlayer-ui/tag blui-tag"
     },
     "dependencies": {
-        "@brightlayer-ui/react-auth-shared": "^3.7.1",
+        "@brightlayer-ui/react-auth-shared": "^3.7.2-beta.0",
         "lodash.clonedeep": "^4.5.0",
         "react-native-status-bar-height": "^2.5.0"
     },

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -198,6 +198,7 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
     const customDetails = injectedUIContext.customAccountDetails || [];
     const FirstCustomPage: ComponentType<AccountDetailsFormProps> | null =
         customDetails.length > 0 && customDetails[0] ? customDetails[0].component : null;
+    const [shouldFocusFirstCustomInput, setShouldFocusFirstCustomInput] = useState(false);
     const RegistrationPages: RegistrationPage[] = [
         {
             name: 'Eula',
@@ -241,7 +242,8 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
                     onSubmit={
                         FirstCustomPage
                             ? (): void => {
-                                  /* TODO Focus first field in custom page */
+                                  setShouldFocusFirstCustomInput(true);
+                                  setTimeout(() => setShouldFocusFirstCustomInput(false), 0);
                               }
                             : accountDetails !== null // && accountDetails.valid
                             ? /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
@@ -257,6 +259,7 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
                                     0: { values: details || {}, valid },
                                 });
                             }}
+                            shouldFocusFirstCustomInput={shouldFocusFirstCustomInput}
                             initialDetails={customAccountDetails?.[0]?.values}
                             /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
                             onSubmit={customAccountDetails?.[0]?.valid ? (): void => advancePage(1) : undefined}
@@ -308,6 +311,7 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
                                                           (): void => advancePage(1)
                                                         : undefined
                                                 }
+                                                shouldFocusFirstCustomInput={shouldFocusFirstCustomInput}
                                             />
                                         </View>
                                     </KeyboardAwareScrollView>

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -243,6 +243,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
     const customDetails = injectedUIContext.customAccountDetails || [];
     const FirstCustomPage: ComponentType<AccountDetailsFormProps> | null =
         customDetails.length > 0 && customDetails[0] ? customDetails[0].component : null;
+    const [shouldFocusFirstCustomInput, setShouldFocusFirstCustomInput] = useState(false);
     const RegistrationPages: RegistrationPage[] = [
         {
             name: 'Eula',
@@ -326,7 +327,8 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                         onSubmit={
                             FirstCustomPage
                                 ? (): void => {
-                                      /* TODO Focus first field in custom page */
+                                      setShouldFocusFirstCustomInput(true);
+                                      setTimeout(() => setShouldFocusFirstCustomInput(false), 0);
                                   }
                                 : accountDetails !== null // && accountDetails.valid
                                 ? /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
@@ -342,6 +344,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                                         0: { values: details || {}, valid },
                                     });
                                 }}
+                                shouldFocusFirstCustomInput={shouldFocusFirstCustomInput}
                                 initialDetails={customAccountDetails?.[0]?.values}
                                 /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
                                 onSubmit={customAccountDetails?.[0]?.valid ? (): void => advancePage(1) : undefined}
@@ -394,6 +397,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
                                                           (): void => advancePage(1)
                                                         : undefined
                                                 }
+                                                shouldFocusFirstCustomInput={shouldFocusFirstCustomInput}
                                             />
                                         </View>
                                     </KeyboardAwareScrollView>

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1086,10 +1086,10 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-auth-shared@^3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.1.tgz#e8ee16f592a4225f9ef9de2f8741bdc941f9cf55"
-  integrity sha512-Kmvmj2pPTTp1v1TE38ZmrTtGhQcnEeY+7pnU/fE39A1dzNTn3nX5ZWGrysfoDU5c33lvWbJIsss7PUCaOKZ3nA==
+"@brightlayer-ui/react-auth-shared@^3.7.2-beta.0":
+  version "3.7.2-beta.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.2-beta.0.tgz#29b2cf065b822fc40663b2fd550753a1d9e82dd9"
+  integrity sha512-g83+YrPMU1OB0temlMNiuKUx+f6yvMst2pWvCZPBTbKTEGk5rMcApr3GkNvKz3rQx1f0dwdwIQSqlwKzgGMltw==
 
 "@brightlayer-ui/react-native-components@^6.0.3":
   version "6.0.3"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #73 & BLUI-2966.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix keyboard next button for navigating between default account details and custom account details

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
https://user-images.githubusercontent.com/13989985/184700129-fade0632-1700-424c-a2eb-932d96135a61.mov

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `git clone git@github.com:brightlayer-ui/react-native-workflows.git`
- `git checkout feature/blui-2966-fix-keyboard-next-button`
- `yarn initialize`
- `cd shared-auth && git checkout feature/blui-2966-fix-keyboard-next-button`
- `yarn start:example`
- check both "Invite Register" and "Self Register" flows to ensure that you can navigate between pages and form fields using the native keyboard next buttons.
