### PR TITLE
fix bug blui 3309 keyboard

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Issue with Eula checkbox alignment ([#76](https://github.com/brightlayer-ui/react-native-workflows/issues/76)).
 -   Fixed `<MobileStepper>` and `<RequirementCheck>` active/valid state color in dark theme ([#161](https://github.com/brightlayer-ui/react-native-workflows/issues/161)).
+-   Fixed keyboard dismissed on initial click on input fields ([#130](https://github.com/brightlayer-ui/react-native-workflows/issues/130)).
 
 ### Added
 

--- a/login-workflow/example/android/app/src/main/AndroidManifest.xml
+++ b/login-workflow/example/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="stateAlwaysHidden|adjustPan">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes https://github.com/brightlayer-ui/react-native-workflows/issues/130 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- update android manifest (android:windowSoftInputMode="stateAlwaysHidden|adjustPan")
- "stateAlwaysHidden" | The soft keyboard is always hidden when the activity's main window has input focus.
- "adjustPan" | The activity's main window is not resized to make room for the soft keyboard. Rather, the contents of the window are automatically panned so that the current focus is never obscured by the keyboard and users can always see what they are typing. This is generally less desirable than resizing, because the user may need to close the soft keyboard to get at and interact with obscured parts of the window.

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- switch shared auth to dev
- yarn start:example-android
- select any input field and notice keyboard remains open.

https://developer.android.com/guide/topics/manifest/activity-element#wsoft