### PR TITLE
BLUI-2965 Fix scroll container

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Issue with Eula checkbox alignment ([#76](https://github.com/brightlayer-ui/react-native-workflows/issues/76)).
+-   Fixed issue with Eula checkbox alignment ([#76](https://github.com/brightlayer-ui/react-native-workflows/issues/76)).
 -   Fixed `<MobileStepper>` and `<RequirementCheck>` active/valid state color in dark theme ([#161](https://github.com/brightlayer-ui/react-native-workflows/issues/161)).
+-   Fixed issue with scroll containers not filling the screen ([#75](https://github.com/brightlayer-ui/react-native-workflows/issues/75)).
+-   Fixed issue with Eula text not being centered ([#164](https://github.com/brightlayer-ui/react-native-workflows/issues/164)).
 
 ### Added
 

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -423,7 +423,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
+  FBReactNativeSpec: cca4f188bf76042a163ec490f8596d914702acba
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -59,7 +59,7 @@ import Color from 'color';
 const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any> =>
     StyleSheet.create({
         safeContainer: {
-            height: '100%',
+            flexGrow: 1,
             backgroundColor: theme.colors.surface,
         },
         mainContainer: {
@@ -72,9 +72,16 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
             flex: 1,
             height: '100%',
         },
+        scrollContainer: {
+            flex: 1,
+            alignContent: 'center',
+        },
+        scrollContentContainer: {
+            alignSelf: 'center',
+            maxWidth: 600,
+        },
         divider: {
             height: 1,
-            // marginTop: 16,
             backgroundColor: theme.dark
                 ? Color(Colors.black[200]).alpha(0.36).toString()
                 : Color(Colors.black[500]).alpha(0.12).toString(),
@@ -285,33 +292,34 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
                                 key={`CustomDetailsPage_${i + 1}`}
                                 style={{ width: '100%', flexDirection: 'row', justifyContent: 'center' }}
                             >
-                                <View style={{ width: '100%', maxWidth: 600 }}>
-                                    <KeyboardAwareScrollView>
-                                        {page.instructions && (
-                                            <Instruction text={page.instructions} style={{ marginHorizontal: 16 }} />
-                                        )}
-                                        <View style={{ flex: 1, marginHorizontal: 16 }}>
-                                            <PageComponent
-                                                onDetailsChanged={(
-                                                    details: CustomAccountDetails | null,
-                                                    valid: boolean
-                                                ): void => {
-                                                    setCustomAccountDetails({
-                                                        ...customAccountDetails,
-                                                        [i + 1]: { values: details || {}, valid },
-                                                    });
-                                                }}
-                                                initialDetails={customAccountDetails?.[i + 1]?.values}
-                                                onSubmit={
-                                                    customAccountDetails?.[i + 1]?.valid
-                                                        ? /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                                                          (): void => advancePage(1)
-                                                        : undefined
-                                                }
-                                            />
-                                        </View>
-                                    </KeyboardAwareScrollView>
-                                </View>
+                                <KeyboardAwareScrollView
+                                    style={containerStyles.scrollContainer}
+                                    contentContainerStyle={[containerStyles.scrollContentContainer]}
+                                >
+                                    {page.instructions && (
+                                        <Instruction text={page.instructions} style={{ marginHorizontal: 16 }} />
+                                    )}
+                                    <View style={{ flex: 1, marginHorizontal: 16 }}>
+                                        <PageComponent
+                                            onDetailsChanged={(
+                                                details: CustomAccountDetails | null,
+                                                valid: boolean
+                                            ): void => {
+                                                setCustomAccountDetails({
+                                                    ...customAccountDetails,
+                                                    [i + 1]: { values: details || {}, valid },
+                                                });
+                                            }}
+                                            initialDetails={customAccountDetails?.[i + 1]?.values}
+                                            onSubmit={
+                                                customAccountDetails?.[i + 1]?.valid
+                                                    ? /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                                                      (): void => advancePage(1)
+                                                    : undefined
+                                            }
+                                        />
+                                    </View>
+                                </KeyboardAwareScrollView>
                             </SafeAreaView>
                         ),
                         canGoForward: customAccountDetails ? customAccountDetails?.[i + 1]?.valid : false,

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -65,9 +65,6 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
             height: '100%',
             backgroundColor: theme.colors.surface,
         },
-        mainContainer: {
-            flex: 1,
-        },
         containerMargins: {
             marginHorizontal: 16,
         },
@@ -248,18 +245,15 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'Eula',
             pageTitle: t('blui:REGISTRATION.STEPS.LICENSE'),
             pageBody: (
-                // This View wrapper is necessary to avoid an issue with the pager-view where the EULA screen
-                // doesn't load. It only works if we put it here (doesn't work if added to the Eula component).
-                <View key={'EulaPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <EulaScreen
-                        eulaAccepted={eulaAccepted}
-                        onEulaChanged={setEulaAccepted}
-                        loadEula={loadAndCacheEula}
-                        htmlEula={injectedUIContext.htmlEula ?? false}
-                        eulaError={loadEulaTransitErrorMessage}
-                        eulaContent={eulaContent}
-                    />
-                </View>
+                <EulaScreen
+                    key={'EulaPage'}
+                    eulaAccepted={eulaAccepted}
+                    onEulaChanged={setEulaAccepted}
+                    loadEula={loadAndCacheEula}
+                    htmlEula={injectedUIContext.htmlEula ?? false}
+                    eulaError={loadEulaTransitErrorMessage}
+                    eulaContent={eulaContent}
+                />
             ),
             canGoForward: eulaAccepted,
             canGoBack: true,
@@ -268,14 +262,13 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'CreateAccount',
             pageTitle: t('blui:REGISTRATION.STEPS.CREATE_ACCOUNT'),
             pageBody: (
-                <View key={'CreateAccountPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <CreateAccountScreen
-                        onEmailChanged={onEmailChanged}
-                        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                        onSubmit={(): void => advancePage(1)}
-                        initialEmail={email}
-                    />
-                </View>
+                <CreateAccountScreen
+                    key={'CreateAccountPage'}
+                    onEmailChanged={onEmailChanged}
+                    /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                    onSubmit={(): void => advancePage(1)}
+                    initialEmail={email}
+                />
             ),
             canGoForward: email.length > 0,
             canGoBack: true,
@@ -284,17 +277,16 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'VerifyEmail',
             pageTitle: t('blui:REGISTRATION.STEPS.VERIFY_EMAIL'),
             pageBody: (
-                <View key={'VerifyEmailPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <VerifyEmailScreen
-                        initialCode={verificationCode}
-                        onVerifyCodeChanged={setVerificationCode}
-                        onResendVerificationEmail={(): void => {
-                            void requestCode();
-                        }}
-                        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                        onSubmit={(): void => advancePage(1)}
-                    />
-                </View>
+                <VerifyEmailScreen
+                    key={'VerifyEmailPage'}
+                    initialCode={verificationCode}
+                    onVerifyCodeChanged={setVerificationCode}
+                    onResendVerificationEmail={(): void => {
+                        void requestCode();
+                    }}
+                    /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                    onSubmit={(): void => advancePage(1)}
+                />
             ),
             canGoForward: verificationCode.length > 0,
             canGoBack: true,
@@ -303,15 +295,13 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'CreatePassword',
             pageTitle: t('blui:REGISTRATION.STEPS.PASSWORD'),
             pageBody: (
-                <View key={'CreatePasswordPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <KeyboardAwareScrollView contentContainerStyle={[containerStyles.fullFlex]}>
-                        <CreatePasswordScreen
-                            onPasswordChanged={setPassword}
-                            /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                            onSubmit={(): void => advancePage(1)}
-                        />
-                    </KeyboardAwareScrollView>
-                </View>
+                <KeyboardAwareScrollView key={'CreatePasswordPage'} contentContainerStyle={[containerStyles.fullFlex]}>
+                    <CreatePasswordScreen
+                        onPasswordChanged={setPassword}
+                        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                        onSubmit={(): void => advancePage(1)}
+                    />
+                </KeyboardAwareScrollView>
             ),
             canGoForward: password.length > 0,
             canGoBack: true,
@@ -320,35 +310,34 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'AccountDetails',
             pageTitle: t('blui:REGISTRATION.STEPS.ACCOUNT_DETAILS'),
             pageBody: (
-                <View key={'AccountDetailsPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <AccountDetailsScreen
-                        onDetailsChanged={setAccountDetails}
-                        onSubmit={
-                            FirstCustomPage
-                                ? (): void => {
-                                      /* TODO Focus first field in custom page */
-                                  }
-                                : accountDetails !== null // && accountDetails.valid
-                                ? /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                                  (): void => advancePage(1)
-                                : undefined
-                        }
-                    >
-                        {FirstCustomPage && (
-                            <FirstCustomPage
-                                onDetailsChanged={(details: CustomAccountDetails | null, valid: boolean): void => {
-                                    setCustomAccountDetails({
-                                        ...(customAccountDetails || {}),
-                                        0: { values: details || {}, valid },
-                                    });
-                                }}
-                                initialDetails={customAccountDetails?.[0]?.values}
-                                /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                                onSubmit={customAccountDetails?.[0]?.valid ? (): void => advancePage(1) : undefined}
-                            />
-                        )}
-                    </AccountDetailsScreen>
-                </View>
+                <AccountDetailsScreen
+                    key={'AccountDetailsPage'}
+                    onDetailsChanged={setAccountDetails}
+                    onSubmit={
+                        FirstCustomPage
+                            ? (): void => {
+                                  /* TODO Focus first field in custom page */
+                              }
+                            : accountDetails !== null // && accountDetails.valid
+                            ? /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                              (): void => advancePage(1)
+                            : undefined
+                    }
+                >
+                    {FirstCustomPage && (
+                        <FirstCustomPage
+                            onDetailsChanged={(details: CustomAccountDetails | null, valid: boolean): void => {
+                                setCustomAccountDetails({
+                                    ...(customAccountDetails || {}),
+                                    0: { values: details || {}, valid },
+                                });
+                            }}
+                            initialDetails={customAccountDetails?.[0]?.values}
+                            /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                            onSubmit={customAccountDetails?.[0]?.valid ? (): void => advancePage(1) : undefined}
+                        />
+                    )}
+                </AccountDetailsScreen>
             ),
             canGoForward: accountDetails !== null, // &&
             // accountDetails.valid,

--- a/login-workflow/src/subScreens/AccountDetails.tsx
+++ b/login-workflow/src/subScreens/AccountDetails.tsx
@@ -23,7 +23,6 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
         safeContainer: {
             height: '100%',
             backgroundColor: theme.colors.surface,
-            // width: '100%',
             flexDirection: 'row',
             justifyContent: 'center',
         },
@@ -118,7 +117,6 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
 
     return (
         <SafeAreaView style={containerStyles.safeContainer}>
-            {/* <View style={{ width: '100%', maxWidth: 600 }}> */}
             <KeyboardAwareScrollView
                 style={containerStyles.scrollContainer}
                 contentContainerStyle={[containerStyles.scrollContentContainer]}
@@ -159,7 +157,6 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
                     {props.children}
                 </View>
             </KeyboardAwareScrollView>
-            {/* </View> */}
         </SafeAreaView>
     );
 };

--- a/login-workflow/src/subScreens/AccountDetails.tsx
+++ b/login-workflow/src/subScreens/AccountDetails.tsx
@@ -23,7 +23,7 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
         safeContainer: {
             height: '100%',
             backgroundColor: theme.colors.surface,
-            width: '100%',
+            // width: '100%',
             flexDirection: 'row',
             justifyContent: 'center',
         },
@@ -33,6 +33,14 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
         },
         containerMargins: {
             marginHorizontal: 16,
+        },
+        scrollContainer: {
+            flex: 1,
+            alignContent: 'center',
+        },
+        scrollContentContainer: {
+            alignSelf: 'center',
+            maxWidth: 600,
         },
     });
 
@@ -110,45 +118,48 @@ export const AccountDetails: React.FC<AccountDetailsProps> = (props) => {
 
     return (
         <SafeAreaView style={containerStyles.safeContainer}>
-            <View style={{ width: '100%', maxWidth: 600 }}>
-                <KeyboardAwareScrollView>
-                    <Instruction
-                        text={t('blui:REGISTRATION.INSTRUCTIONS.ACCOUNT_DETAILS')}
-                        style={containerStyles.containerMargins}
+            {/* <View style={{ width: '100%', maxWidth: 600 }}> */}
+            <KeyboardAwareScrollView
+                style={containerStyles.scrollContainer}
+                contentContainerStyle={[containerStyles.scrollContentContainer]}
+            >
+                <Instruction
+                    text={t('blui:REGISTRATION.INSTRUCTIONS.ACCOUNT_DETAILS')}
+                    style={containerStyles.containerMargins}
+                />
+
+                <View style={[containerStyles.containerMargins, containerStyles.mainContainer]}>
+                    <TextInput
+                        label={t('blui:FORMS.FIRST_NAME')}
+                        value={firstNameInput}
+                        style={styles.inputMargin}
+                        autoCapitalize={'sentences'}
+                        returnKeyType={'next'}
+                        onChangeText={(text: string): void => setFirstNameInput(text)}
+                        onSubmitEditing={(): void => {
+                            goToLastName();
+                        }}
+                        blurOnSubmit={false}
+                        maxLength={firstNameLengthLimit}
                     />
 
-                    <View style={[containerStyles.containerMargins, containerStyles.mainContainer]}>
-                        <TextInput
-                            label={t('blui:FORMS.FIRST_NAME')}
-                            value={firstNameInput}
-                            style={styles.inputMargin}
-                            autoCapitalize={'sentences'}
-                            returnKeyType={'next'}
-                            onChangeText={(text: string): void => setFirstNameInput(text)}
-                            onSubmitEditing={(): void => {
-                                goToLastName();
-                            }}
-                            blurOnSubmit={false}
-                            maxLength={firstNameLengthLimit}
-                        />
-
-                        <TextInput
-                            ref={lastNameRef}
-                            label={t('blui:FORMS.LAST_NAME')}
-                            value={lastNameInput}
-                            style={styles.inputMargin}
-                            autoCapitalize={'sentences'}
-                            returnKeyType={'next'}
-                            onChangeText={(text: string): void => setLastNameInput(text)}
-                            onSubmitEditing={
-                                firstNameInput.length > 0 && lastNameInput.length > 0 ? props.onSubmit : undefined
-                            }
-                            maxLength={lastNameLengthLimit}
-                        />
-                        {props.children}
-                    </View>
-                </KeyboardAwareScrollView>
-            </View>
+                    <TextInput
+                        ref={lastNameRef}
+                        label={t('blui:FORMS.LAST_NAME')}
+                        value={lastNameInput}
+                        style={styles.inputMargin}
+                        autoCapitalize={'sentences'}
+                        returnKeyType={'next'}
+                        onChangeText={(text: string): void => setLastNameInput(text)}
+                        onSubmitEditing={
+                            firstNameInput.length > 0 && lastNameInput.length > 0 ? props.onSubmit : undefined
+                        }
+                        maxLength={lastNameLengthLimit}
+                    />
+                    {props.children}
+                </View>
+            </KeyboardAwareScrollView>
+            {/* </View> */}
         </SafeAreaView>
     );
 };

--- a/login-workflow/src/subScreens/Eula.tsx
+++ b/login-workflow/src/subScreens/Eula.tsx
@@ -28,7 +28,7 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
             flex: 1,
             paddingTop: 16,
             width: 'auto',
-            flexDirection: 'row',
+            flexDirection: 'column',
             justifyContent: 'center',
         },
         containerMargins: {
@@ -37,9 +37,18 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
         checkboxContainer: {
             height: 72,
             justifyContent: 'center',
-            alignSelf: 'stretch',
             marginRight: 16,
             marginLeft: -10,
+            maxWidth: 600,
+            alignSelf: 'stretch',
+        },
+        scrollContainer: {
+            flex: 1,
+            alignContent: 'center',
+        },
+        scrollContentContainer: {
+            alignSelf: 'center',
+            maxWidth: 600,
         },
     });
 
@@ -103,32 +112,33 @@ export const Eula: React.FC<EulaProps> = (props) => {
     return (
         <SafeAreaView style={[containerStyles.safeContainer]}>
             <View style={[containerStyles.mainContainer, containerStyles.containerMargins]}>
-                <View style={{ flex: 1, maxWidth: 600 }}>
-                    {htmlEula ? (
-                        <WebView
-                            originWhitelist={['*']}
-                            source={{ html: eulaContentInternals, baseUrl: '' }}
-                            scalesPageToFit={false}
-                            onLoadEnd={onLoadEnd}
-                            style={{
-                                flex: 1,
-                                height: 50 /* WebView needs a fixed height set or it won't render */,
-                                backgroundColor: theme.colors.surface,
-                            }}
-                        />
-                    ) : (
-                        <ScrollView>
-                            <Body1>{eulaContentInternals}</Body1>
-                        </ScrollView>
-                    )}
-                    <View style={[containerStyles.checkboxContainer]}>
-                        <Checkbox
-                            label={t('blui:REGISTRATION.EULA.AGREE_TERMS')}
-                            disabled={disableCheckBox}
-                            checked={eulaIsChecked}
-                            onPress={checkedBox}
-                        />
-                    </View>
+                {htmlEula ? (
+                    <WebView
+                        originWhitelist={['*']}
+                        source={{ html: eulaContentInternals, baseUrl: '' }}
+                        scalesPageToFit={false}
+                        onLoadEnd={onLoadEnd}
+                        style={{
+                            flex: 1,
+                            height: 50 /* WebView needs a fixed height set or it won't render */,
+                            backgroundColor: theme.colors.surface,
+                        }}
+                    />
+                ) : (
+                    <ScrollView
+                        style={containerStyles.scrollContainer}
+                        contentContainerStyle={[containerStyles.scrollContentContainer]}
+                    >
+                        <Body1>{eulaContentInternals}</Body1>
+                    </ScrollView>
+                )}
+                <View style={[containerStyles.checkboxContainer]}>
+                    <Checkbox
+                        label={t('blui:REGISTRATION.EULA.AGREE_TERMS')}
+                        disabled={disableCheckBox}
+                        checked={eulaIsChecked}
+                        onPress={checkedBox}
+                    />
                 </View>
             </View>
         </SafeAreaView>

--- a/login-workflow/src/subScreens/ResetPassword.tsx
+++ b/login-workflow/src/subScreens/ResetPassword.tsx
@@ -34,7 +34,6 @@ import {
 const makeContainerStyles = (theme: ReactNativePaper.Theme, insets: any): Record<string, any> =>
     StyleSheet.create({
         safeContainer: {
-            // height: '100%',
             flexGrow: 1,
             backgroundColor: theme.colors.surface,
             marginBottom: insets.bottom,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #75 & BLUI-2965.

Fixes #164 as well.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Make scroll containers fill the screen 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `git clone git@github.com:brightlayer-ui/react-native-workflows.git`
- `git checkout feature/blui-2965-fix-scroll-container`
- `yarn start:example-ipad`
- If the ipad script doesn't work update the example script for ipad to suit your local environment needs
- check all workflows and ensure that you can scroll from anywhere, not just the inner 600px of content

Disclaimer: I need to and have yet to thoroughly test this tested across all devices so I'll be manually testing further on physical devices and android while this PR is open. Just want to get eyes on it sooner than later in case there are issues.

I will write another story to address the alignment of the checkbox button for the EULA page as well. Not worth the time I already spent on it and it's technically out of scope for this story anyway. 