### PR TITLE
BLUI-2968 - Add login error message configuration functionality

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -15,10 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Fixed issue with Eula text not being centered ([#164](https://github.com/brightlayer-ui/react-native-workflows/issues/164)).
 -   Fixed keyboard dismissal on initial click of input fields ([#130](https://github.com/brightlayer-ui/react-native-workflows/issues/130)).
 
-
 ### Added
 
 -   Added support for Portuguese translations ([#110](https://github.com/brightlayer-ui/react-native-workflows/issues/110)).
+-   Ability to customize how error messages are displayed on the login screen via the `loginErrorDisplayConfig` prop on the `AuthUIContextProvider` ([#124](https://github.com/brightlayer-ui/react-native-workflows/issues/124)).
 
 ### Changed
 

--- a/login-workflow/example/App.tsx
+++ b/login-workflow/example/App.tsx
@@ -74,6 +74,7 @@ export const AuthUIConfiguration: React.FC = (props) => {
             contactEmail={'something@email.com'}
             contactPhone={'1-800-123-4567'}
             contactPhoneLink={'1-800-123-4567'}
+            // loginErrorDisplayConfig={{ mode: 'message-box', position: 'top' }}
             // customAccountDetails={[
             //     { component: CustomAccountDetails },
             //     {

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -423,7 +423,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: cca4f188bf76042a163ec490f8596d914702acba
+  FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -423,7 +423,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
+  FBReactNativeSpec: cca4f188bf76042a163ec490f8596d914702acba
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -57,7 +57,7 @@
         "tag-package": "npx -p @brightlayer-ui/tag blui-tag"
     },
     "dependencies": {
-        "@brightlayer-ui/react-auth-shared": "^3.7.2-beta.0",
+        "@brightlayer-ui/react-auth-shared": "^3.7.2-beta.1",
         "lodash.clonedeep": "^4.5.0",
         "react-native-status-bar-height": "^2.5.0"
     },

--- a/login-workflow/src/__tests__/screens/Login-test.tsx
+++ b/login-workflow/src/__tests__/screens/Login-test.tsx
@@ -13,6 +13,7 @@ import renderer from 'react-test-renderer';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import 'react-native-gesture-handler';
+import { Provider } from 'react-native-paper';
 const Stack = createStackNavigator();
 
 // mock hooks
@@ -32,17 +33,19 @@ describe('Login screen tested with enzyme', () => {
 
     function baseXML(): JSX.Element {
         return (
-            <NavigationContainer>
-                <Stack.Navigator>
-                    <Stack.Screen
-                        name="Login"
-                        component={Login}
-                        options={(): any => ({
-                            header: (): JSX.Element => <></>,
-                        })}
-                    />
-                </Stack.Navigator>
-            </NavigationContainer>
+            <Provider>
+                <NavigationContainer>
+                    <Stack.Navigator>
+                        <Stack.Screen
+                            name="Login"
+                            component={Login}
+                            options={(): any => ({
+                                header: (): JSX.Element => <></>,
+                            })}
+                        />
+                    </Stack.Navigator>
+                </NavigationContainer>
+            </Provider>
         );
     }
 

--- a/login-workflow/src/screens/Login.tsx
+++ b/login-workflow/src/screens/Login.tsx
@@ -110,7 +110,7 @@ const makeStyles = (theme: Theme, config: LoginErrorDisplayConfig): Record<strin
             borderRadius: 4,
             padding: 16,
             color: config.fontColor || Colors.white['50'],
-            marginHorizontal: 16,
+            marginHorizontal: config.position !== 'bottom' ? 16 : 0,
             marginTop: config.position !== 'bottom' ? 8 : 16,
             marginBottom: config.position !== 'bottom' ? 0 : -8,
         },

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1086,10 +1086,10 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-auth-shared@^3.7.2-beta.0":
-  version "3.7.2-beta.0"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.2-beta.0.tgz#29b2cf065b822fc40663b2fd550753a1d9e82dd9"
-  integrity sha512-g83+YrPMU1OB0temlMNiuKUx+f6yvMst2pWvCZPBTbKTEGk5rMcApr3GkNvKz3rQx1f0dwdwIQSqlwKzgGMltw==
+"@brightlayer-ui/react-auth-shared@^3.7.2-beta.1":
+  version "3.7.2-beta.1"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.2-beta.1.tgz#bc52e795b650a3fae27d64b18e54c6b53473a689"
+  integrity sha512-Z4xWu4RoWYaH5gpB/u+od3ICbDmEhbHkp5wm5uQvpEDqKfzTmyMRJ38t4ho6U6WL33X1AiHQrXKcZo5SMPyPJA==
 
 "@brightlayer-ui/react-native-components@^6.0.3":
   version "6.0.3"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #124 & BLUI-2968.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add ability to customize how login error messages are displayed

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `git clone git@github.com:brightlayer-ui/react-native-workflows.git -b feature/blui-2968-login-error-display-config`
- `cd react-native-workflows/login-workflow`
- Modify example `AuthUiActions.tsx` login method to immediately return an error (e.g., `throw new Error('LOGIN.INVALID_CREDENTIALS');` || `throw new Error('error message...');`)
- Add a loginErrorDisplayConfig to the example `App.tsx` (see examples below)
- `yarn start:example`
- Observe various error message configs

example configs
` loginErrorDisplayConfig={{ mode: 'dialog' }}`
`loginErrorDisplayConfig={{ mode: 'message-box', position: 'top' }}`
`loginErrorDisplayConfig={{ mode: 'message-box', position: 'bottom' }}`
`loginErrorDisplayConfig={{mode: 'message-box', position: 'top', backgroundColor: '#FFA1FF', fontColor: '#00CA00', dismissible: false }}`
`loginErrorDisplayConfig={{ mode: 'both' }}`
`loginErrorDisplayConfig={{ mode: 'none' }}`
