### PR TITLE
BLUI-2965 - Cleanup: Fix scroll width on registration workflow and change password success screen

### DIFF
--- a/login-workflow/example/App.tsx
+++ b/login-workflow/example/App.tsx
@@ -1,7 +1,7 @@
 import 'react-native-gesture-handler';
 import React from 'react';
 import { Provider as ThemeProvider } from 'react-native-paper';
-import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { SafeAreaProvider /*, useSafeAreaInsets */ } from 'react-native-safe-area-context';
 // import { ThemedButton as Button } from '@brightlayer-ui/react-native-components/themed';
 import * as BLUIThemes from '@brightlayer-ui/react-native-themes';
 import { MainRouter } from './src/navigation';
@@ -63,7 +63,7 @@ declare global {
 
 export const AuthUIConfiguration: React.FC = (props) => {
     const securityContextActions = useSecurityActions();
-    const safeAreaInset = useSafeAreaInsets();
+    // const safeAreaInset = useSafeAreaInsets();
     // const { t } = useTranslation();
     return (
         <AuthUIContextProvider

--- a/login-workflow/example/App.tsx
+++ b/login-workflow/example/App.tsx
@@ -2,7 +2,7 @@ import 'react-native-gesture-handler';
 import React from 'react';
 import { Provider as ThemeProvider } from 'react-native-paper';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
-import { ThemedButton as Button } from '@brightlayer-ui/react-native-components/themed';
+// import { ThemedButton as Button } from '@brightlayer-ui/react-native-components/themed';
 import * as BLUIThemes from '@brightlayer-ui/react-native-themes';
 import { MainRouter } from './src/navigation';
 import { ProjectAuthUIActions } from './src/actions/AuthUIActions';
@@ -12,14 +12,14 @@ import {
     AuthNavigationContainer,
     AuthUIContextProvider,
     useSecurityActions,
-    RegistrationData,
+    // RegistrationData,
     i18n,
 } from '@brightlayer-ui/react-native-auth-workflow';
 import { useLinking } from '@react-navigation/native';
 import { authLinkMapping, resolveInitialState } from './src/navigation/DeepLinking';
-import { Image, ScrollView, View } from 'react-native';
-import { Body1, H5, Header, Hero /*, wrapIcon*/, Spacer } from '@brightlayer-ui/react-native-components';
-import MatIcon from 'react-native-vector-icons/MaterialIcons';
+// import { Image, ScrollView, View } from 'react-native';
+// import { Body1, H5, Header, Hero /*, wrapIcon*/, Spacer } from '@brightlayer-ui/react-native-components';
+// import MatIcon from 'react-native-vector-icons/MaterialIcons';
 // import { CustomAccountDetails, CustomAccountDetailsTwo } from './src/screens/CustomRegistrationForm';
 // import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 // import { Terms } from './src/screens/Terms';
@@ -137,68 +137,68 @@ export const AuthUIConfiguration: React.FC = (props) => {
             //     backgroundColor: 'rgba(255,165,0,0.3)',
             //     backgroundSize: '100%',
             // }}
-            registrationSuccessScreen={(
-                navigation: any,
-                registrationData: RegistrationData | undefined
-            ): JSX.Element => (
-                <View style={{ backgroundColor: '#fff', maxHeight: '100%' }}>
-                    <Header
-                        title={'Custom Title!'}
-                        navigation={{
-                            icon: <MatIcon name="close" />,
-                            onPress: (): void => navigation.navigate('Login'),
-                        }}
-                    />
-                    <ScrollView
-                        style={{
-                            height: '100%',
-                        }}
-                        contentContainerStyle={{
-                            flexGrow: 1,
-                        }}
-                    >
-                        <Image style={{ position: 'absolute' }} source={require('./assets/images/blue_waves.png')} />
-                        <View
-                            style={{
-                                height: '100%',
-                                backgroundColor: 'transparent',
-                            }}
-                        >
-                            <View style={{ justifyContent: 'center', height: 200 }}>
-                                <Hero
-                                    label=""
-                                    icon={<MatIcon name="person" size={48} color={'#fff'} />}
-                                    iconBackgroundColor={'#007bc1'}
-                                    styles={{ iconWrapper: { width: 90, height: 90, borderRadius: 90 } }}
-                                />
-                            </View>
-                            <View
-                                style={{
-                                    marginHorizontal: 16,
-                                    flex: 1,
-                                    marginBottom: safeAreaInset.bottom,
-                                }}
-                            >
-                                <View>
-                                    <H5 style={{ marginBottom: 32 }}>
-                                        Congratulations, {registrationData?.accountDetails?.firstName}!
-                                    </H5>
-                                    <Body1 style={{ marginBottom: 16 }}>
-                                        You made it to the custom success screen! Yay!
-                                    </Body1>
-                                    {registrationData?.email && (
-                                        <Body1>We sent an introductory email to {registrationData.email}.</Body1>
-                                    )}
-                                </View>
-                                <Spacer />
-                                <Button mode="contained" onPress={(): void => navigation.navigate('Login')}>
-                                    <Body1 style={{ color: '#fff' }}>Continue</Body1>
-                                </Button>
-                            </View>
-                        </View>
-                    </ScrollView>
-                </View>
-            )}
+            // registrationSuccessScreen={(
+            //     navigation: any,
+            //     registrationData: RegistrationData | undefined
+            // ): JSX.Element => (
+            //     <View style={{ backgroundColor: '#fff', maxHeight: '100%' }}>
+            //         <Header
+            //             title={'Custom Title!'}
+            //             navigation={{
+            //                 icon: <MatIcon name="close" />,
+            //                 onPress: (): void => navigation.navigate('Login'),
+            //             }}
+            //         />
+            //         <ScrollView
+            //             style={{
+            //                 height: '100%',
+            //             }}
+            //             contentContainerStyle={{
+            //                 flexGrow: 1,
+            //             }}
+            //         >
+            //             <Image style={{ position: 'absolute' }} source={require('./assets/images/blue_waves.png')} />
+            //             <View
+            //                 style={{
+            //                     height: '100%',
+            //                     backgroundColor: 'transparent',
+            //                 }}
+            //             >
+            //                 <View style={{ justifyContent: 'center', height: 200 }}>
+            //                     <Hero
+            //                         label=""
+            //                         icon={<MatIcon name="person" size={48} color={'#fff'} />}
+            //                         iconBackgroundColor={'#007bc1'}
+            //                         styles={{ iconWrapper: { width: 90, height: 90, borderRadius: 90 } }}
+            //                     />
+            //                 </View>
+            //                 <View
+            //                     style={{
+            //                         marginHorizontal: 16,
+            //                         flex: 1,
+            //                         marginBottom: safeAreaInset.bottom,
+            //                     }}
+            //                 >
+            //                     <View>
+            //                         <H5 style={{ marginBottom: 32 }}>
+            //                             Congratulations, {registrationData?.accountDetails?.firstName}!
+            //                         </H5>
+            //                         <Body1 style={{ marginBottom: 16 }}>
+            //                             You made it to the custom success screen! Yay!
+            //                         </Body1>
+            //                         {registrationData?.email && (
+            //                             <Body1>We sent an introductory email to {registrationData.email}.</Body1>
+            //                         )}
+            //                     </View>
+            //                     <Spacer />
+            //                     <Button mode="contained" onPress={(): void => navigation.navigate('Login')}>
+            //                         <Body1 style={{ color: '#fff' }}>Continue</Body1>
+            //                     </Button>
+            //                 </View>
+            //             </View>
+            //         </ScrollView>
+            //     </View>
+            // )}
             // accountAlreadyExistsScreen={(navigation: any): JSX.Element => (
             //     <View style={{ flex: 1, width: '100%', height: '100%', backgroundColor: '#fff' }}>
             //         <Header

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -421,11 +421,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
+  DoubleConversion: a28897a626e417fac264bb26dd72ad0e9af5bfa8
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
-  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
+  glog: 19d4e11abe55266cf98e1e24f94a850a44fdec35
+  RCT-Folly: fa983ee666a7087ebbb1489b453d69cac3581786
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
   React: 98eac01574128a790f0bbbafe2d1a8607291ac24

--- a/login-workflow/example/ios/Podfile.lock
+++ b/login-workflow/example/ios/Podfile.lock
@@ -421,11 +421,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: a28897a626e417fac264bb26dd72ad0e9af5bfa8
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: df7aeca705913a5c6cc4b3e39fbdd534bb1cce64
-  glog: 19d4e11abe55266cf98e1e24f94a850a44fdec35
-  RCT-Folly: fa983ee666a7087ebbb1489b453d69cac3581786
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
+  RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
   React: 98eac01574128a790f0bbbafe2d1a8607291ac24

--- a/login-workflow/src/screens/ChangePassword.tsx
+++ b/login-workflow/src/screens/ChangePassword.tsx
@@ -56,6 +56,14 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
             flex: 1,
             justifyContent: 'space-between',
         },
+        scrollContainer: {
+            flex: 1,
+            alignContent: 'center',
+        },
+        scrollContentContainer: {
+            alignSelf: 'center',
+            maxWidth: 600,
+        },
         mainContainer: {
             marginTop: 8,
             flex: 1,
@@ -213,7 +221,10 @@ export const ChangePassword: React.FC<ChangePasswordProps> = (props) => {
             <SafeAreaView style={[containerStyles.safeContainer, { flexGrow: 1 }]}>
                 {statusBar}
                 <View style={[containerStyles.mainContainer]}>
-                    <ScrollView style={{ maxWidth: 600 }}>
+                    <ScrollView
+                        style={containerStyles.scrollContainer}
+                        contentContainerStyle={containerStyles.scrollContentContainer}
+                    >
                         <MatIcon
                             name={'check'}
                             color={theme.colors.placeholder}

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -65,9 +65,6 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
             height: '100%',
             backgroundColor: theme.colors.surface,
         },
-        mainContainer: {
-            flex: 1,
-        },
         containerMargins: {
             marginHorizontal: 16,
         },
@@ -248,18 +245,15 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'Eula',
             pageTitle: t('blui:REGISTRATION.STEPS.LICENSE'),
             pageBody: (
-                // This View wrapper is necessary to avoid an issue with the pager-view where the EULA screen
-                // doesn't load. It only works if we put it here (doesn't work if added to the Eula component).
-                <View key={'EulaPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <EulaScreen
-                        eulaAccepted={eulaAccepted}
-                        onEulaChanged={setEulaAccepted}
-                        loadEula={loadAndCacheEula}
-                        htmlEula={injectedUIContext.htmlEula ?? false}
-                        eulaError={loadEulaTransitErrorMessage}
-                        eulaContent={eulaContent}
-                    />
-                </View>
+                <EulaScreen
+                    key={'EulaPage'}
+                    eulaAccepted={eulaAccepted}
+                    onEulaChanged={setEulaAccepted}
+                    loadEula={loadAndCacheEula}
+                    htmlEula={injectedUIContext.htmlEula ?? false}
+                    eulaError={loadEulaTransitErrorMessage}
+                    eulaContent={eulaContent}
+                />
             ),
             canGoForward: eulaAccepted,
             canGoBack: true,
@@ -268,14 +262,13 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'CreateAccount',
             pageTitle: t('blui:REGISTRATION.STEPS.CREATE_ACCOUNT'),
             pageBody: (
-                <View key={'CreateAccountPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <CreateAccountScreen
-                        onEmailChanged={onEmailChanged}
-                        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                        onSubmit={(): void => advancePage(1)}
-                        initialEmail={email}
-                    />
-                </View>
+                <CreateAccountScreen
+                    key={'CreateAccountPage'}
+                    onEmailChanged={onEmailChanged}
+                    /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                    onSubmit={(): void => advancePage(1)}
+                    initialEmail={email}
+                />
             ),
             canGoForward: email.length > 0,
             canGoBack: true,
@@ -284,17 +277,16 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'VerifyEmail',
             pageTitle: t('blui:REGISTRATION.STEPS.VERIFY_EMAIL'),
             pageBody: (
-                <View key={'VerifyEmailPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <VerifyEmailScreen
-                        initialCode={verificationCode}
-                        onVerifyCodeChanged={setVerificationCode}
-                        onResendVerificationEmail={(): void => {
-                            void requestCode();
-                        }}
-                        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                        onSubmit={(): void => advancePage(1)}
-                    />
-                </View>
+                <VerifyEmailScreen
+                    key={'VerifyEmailPage'}
+                    initialCode={verificationCode}
+                    onVerifyCodeChanged={setVerificationCode}
+                    onResendVerificationEmail={(): void => {
+                        void requestCode();
+                    }}
+                    /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                    onSubmit={(): void => advancePage(1)}
+                />
             ),
             canGoForward: verificationCode.length > 0,
             canGoBack: true,
@@ -303,15 +295,13 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'CreatePassword',
             pageTitle: t('blui:REGISTRATION.STEPS.PASSWORD'),
             pageBody: (
-                <View key={'CreatePasswordPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <KeyboardAwareScrollView contentContainerStyle={[containerStyles.fullFlex]}>
-                        <CreatePasswordScreen
-                            onPasswordChanged={setPassword}
-                            /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                            onSubmit={(): void => advancePage(1)}
-                        />
-                    </KeyboardAwareScrollView>
-                </View>
+                <KeyboardAwareScrollView key={'CreatePasswordPage'} contentContainerStyle={[containerStyles.fullFlex]}>
+                    <CreatePasswordScreen
+                        onPasswordChanged={setPassword}
+                        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                        onSubmit={(): void => advancePage(1)}
+                    />
+                </KeyboardAwareScrollView>
             ),
             canGoForward: password.length > 0,
             canGoBack: true,
@@ -320,35 +310,34 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
             name: 'AccountDetails',
             pageTitle: t('blui:REGISTRATION.STEPS.ACCOUNT_DETAILS'),
             pageBody: (
-                <View key={'AccountDetailsPage'} style={{ width: '100%', maxWidth: 600 }}>
-                    <AccountDetailsScreen
-                        onDetailsChanged={setAccountDetails}
-                        onSubmit={
-                            FirstCustomPage
-                                ? (): void => {
-                                      /* TODO Focus first field in custom page */
-                                  }
-                                : accountDetails !== null // && accountDetails.valid
-                                ? /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                                  (): void => advancePage(1)
-                                : undefined
-                        }
-                    >
-                        {FirstCustomPage && (
-                            <FirstCustomPage
-                                onDetailsChanged={(details: CustomAccountDetails | null, valid: boolean): void => {
-                                    setCustomAccountDetails({
-                                        ...(customAccountDetails || {}),
-                                        0: { values: details || {}, valid },
-                                    });
-                                }}
-                                initialDetails={customAccountDetails?.[0]?.values}
-                                /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-                                onSubmit={customAccountDetails?.[0]?.valid ? (): void => advancePage(1) : undefined}
-                            />
-                        )}
-                    </AccountDetailsScreen>
-                </View>
+                <AccountDetailsScreen
+                    key={'AccountDetailsPage'}
+                    onDetailsChanged={setAccountDetails}
+                    onSubmit={
+                        FirstCustomPage
+                            ? (): void => {
+                                  /* TODO Focus first field in custom page */
+                              }
+                            : accountDetails !== null // && accountDetails.valid
+                            ? /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                              (): void => advancePage(1)
+                            : undefined
+                    }
+                >
+                    {FirstCustomPage && (
+                        <FirstCustomPage
+                            onDetailsChanged={(details: CustomAccountDetails | null, valid: boolean): void => {
+                                setCustomAccountDetails({
+                                    ...(customAccountDetails || {}),
+                                    0: { values: details || {}, valid },
+                                });
+                            }}
+                            initialDetails={customAccountDetails?.[0]?.values}
+                            /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                            onSubmit={customAccountDetails?.[0]?.valid ? (): void => advancePage(1) : undefined}
+                        />
+                    )}
+                </AccountDetailsScreen>
             ),
             canGoForward: accountDetails !== null, // &&
             // accountDetails.valid,

--- a/login-workflow/src/subScreens/CreateAccount.tsx
+++ b/login-workflow/src/subScreens/CreateAccount.tsx
@@ -32,6 +32,14 @@ const makeContainerStyles = (theme: ReactNativePaper.Theme): Record<string, any>
             flexDirection: 'row',
             justifyContent: 'center',
         },
+        scrollContainer: {
+            flex: 1,
+            alignContent: 'center',
+        },
+        scrollContentContainer: {
+            alignSelf: 'center',
+            maxWidth: 600,
+        },
         mainContainer: {
             flex: 1,
             marginTop: 8,
@@ -87,39 +95,36 @@ export const CreateAccount: React.FC<CreateAccountProps> = (props) => {
 
     return (
         <SafeAreaView style={containerStyles.safeContainer}>
-            <View style={{ width: '100%', maxWidth: 600 }}>
-                <KeyboardAwareScrollView>
-                    <Instruction
-                        style={containerStyles.containerMargins}
-                        text={t('blui:SELF_REGISTRATION.INSTRUCTIONS')}
-                    />
+            <KeyboardAwareScrollView
+                style={containerStyles.scrollContainer}
+                contentContainerStyle={containerStyles.scrollContentContainer}
+            >
+                <Instruction style={containerStyles.containerMargins} text={t('blui:SELF_REGISTRATION.INSTRUCTIONS')} />
 
-                    <View style={[containerStyles.containerMargins, containerStyles.mainContainer]}>
-                        <TextInput
-                            label={t('blui:LABELS.EMAIL')}
-                            value={emailInput}
-                            style={styles.inputMargin}
-                            keyboardType={'email-address'}
-                            autoCapitalize={'none'}
-                            error={hasEmailFormatError}
-                            errorText={hasEmailFormatError ? t('blui:MESSAGES.EMAIL_ENTRY_ERROR') : ''}
-                            onChangeText={(text: string): void => {
-                                setEmailInput(text);
-                                setHasEmailFormatError(false);
-                                const validEmailOrEmpty = EMAIL_REGEX.test(text) ? text : '';
-                                props.onEmailChanged(validEmailOrEmpty);
-                            }}
-                            onBlur={(): void => {
-                                if (emailInput.length > 0 && !EMAIL_REGEX.test(emailInput))
-                                    setHasEmailFormatError(true);
-                            }}
-                            onSubmitEditing={
-                                emailInput.length > 0 && EMAIL_REGEX.test(emailInput) ? props.onSubmit : undefined
-                            }
-                        />
-                    </View>
-                </KeyboardAwareScrollView>
-            </View>
+                <View style={[containerStyles.containerMargins, containerStyles.mainContainer]}>
+                    <TextInput
+                        label={t('blui:LABELS.EMAIL')}
+                        value={emailInput}
+                        style={styles.inputMargin}
+                        keyboardType={'email-address'}
+                        autoCapitalize={'none'}
+                        error={hasEmailFormatError}
+                        errorText={hasEmailFormatError ? t('blui:MESSAGES.EMAIL_ENTRY_ERROR') : ''}
+                        onChangeText={(text: string): void => {
+                            setEmailInput(text);
+                            setHasEmailFormatError(false);
+                            const validEmailOrEmpty = EMAIL_REGEX.test(text) ? text : '';
+                            props.onEmailChanged(validEmailOrEmpty);
+                        }}
+                        onBlur={(): void => {
+                            if (emailInput.length > 0 && !EMAIL_REGEX.test(emailInput)) setHasEmailFormatError(true);
+                        }}
+                        onSubmitEditing={
+                            emailInput.length > 0 && EMAIL_REGEX.test(emailInput) ? props.onSubmit : undefined
+                        }
+                    />
+                </View>
+            </KeyboardAwareScrollView>
         </SafeAreaView>
     );
 };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #75 & BLUI-2965.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Make scroll containers fill the screen for registration workflow email screen and the change password success screen

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `git clone git@github.com:brightlayer-ui/react-native-workflows.git -b feature/blui-2965-fix-scroll-container`
- `yarn start:example-ipad`
- If the ipad script doesn't work update the example script for ipad to suit your local environment needs
- check self registration workflow email screen and the change password success screen and ensure that you can scroll from anywhere, not just the inner 600px of content