### PR TITLE
Use new AccountDetailsFormMobileProps type from shared-auth

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v5.0.1 (Unreleased)
+
+### Changed
+
+-   Use the new `AccountDetailsFormMobileProps` type definition in place of `AccountDetailsFormProps`.
+
 ## v5.0.0 (October 31, 2022)
 
 ### Changed

--- a/login-workflow/example/App.tsx
+++ b/login-workflow/example/App.tsx
@@ -20,7 +20,7 @@ import { authLinkMapping, resolveInitialState } from './src/navigation/DeepLinki
 // import { Image, ScrollView, View } from 'react-native';
 // import { Body1, H5, Header, Hero /*, wrapIcon*/, Spacer } from '@brightlayer-ui/react-native-components';
 // import MatIcon from 'react-native-vector-icons/MaterialIcons';
-// import { CustomAccountDetails, CustomAccountDetailsTwo } from './src/screens/CustomRegistrationForm';
+import { CustomAccountDetails, CustomAccountDetailsTwo } from './src/screens/CustomRegistrationForm';
 // import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 // import { Terms } from './src/screens/Terms';
 
@@ -75,14 +75,14 @@ export const AuthUIConfiguration: React.FC = (props) => {
             contactPhone={'1-800-123-4567'}
             contactPhoneLink={'1-800-123-4567'}
             // loginErrorDisplayConfig={{ mode: 'message-box', position: 'top' }}
-            // customAccountDetails={[
-            //     { component: CustomAccountDetails },
-            //     {
-            //         title: 'Job Info',
-            //         instructions: 'Enter your employment information below.',
-            //         component: CustomAccountDetailsTwo,
-            //     },
-            // ]}
+            customAccountDetails={[
+                { component: CustomAccountDetails },
+                {
+                    title: 'Job Info',
+                    instructions: 'Enter your employment information below.',
+                    component: CustomAccountDetailsTwo,
+                },
+            ]}
             // loginType={'username'}
             // disablePagerAnimation={true}
             // registrationConfig={{

--- a/login-workflow/example/src/screens/CustomRegistrationForm.tsx
+++ b/login-workflow/example/src/screens/CustomRegistrationForm.tsx
@@ -5,7 +5,7 @@ import { View, StyleSheet, TextInput as ReactTextInput } from 'react-native';
 import { TextInput } from '../components/TextInput';
 
 // Hooks
-import { AccountDetailsFormProps } from '@brightlayer-ui/react-auth-shared';
+import { AccountDetailsFormMobileProps } from '@brightlayer-ui/react-auth-shared';
 
 /**
  * @ignore
@@ -33,7 +33,7 @@ const makeStyles = (): Record<string, any> =>
  *
  * @category Component
  */
-export const CustomAccountDetails: React.FC<AccountDetailsFormProps> = forwardRef((props, ref) => {
+export const CustomAccountDetails: React.FC<AccountDetailsFormMobileProps> = forwardRef((props, ref) => {
     const styles = makeStyles();
     const containerStyles = makeContainerStyles();
 
@@ -83,7 +83,7 @@ export const CustomAccountDetails: React.FC<AccountDetailsFormProps> = forwardRe
     );
 });
 
-export const CustomAccountDetailsTwo: React.FC<AccountDetailsFormProps> = (props) => {
+export const CustomAccountDetailsTwo: React.FC<AccountDetailsFormMobileProps> = (props) => {
     const styles = makeStyles();
     const containerStyles = makeContainerStyles();
 

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-native-auth-workflow",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",
-    "version": "5.0.0",
+    "version": "5.0.1-alpha.0",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -44,7 +44,7 @@ import {
     // Hooks
     useLanguageLocale,
     useInjectedUIContext,
-    AccountDetailsFormProps,
+    AccountDetailsFormMobileProps,
     CustomAccountDetails,
     CustomRegistrationForm,
 } from '@brightlayer-ui/react-auth-shared';
@@ -204,7 +204,7 @@ export const InviteRegistrationPager: React.FC<InviteRegistrationPagerProps> = (
 
     // Page Definitions
     const customDetails = injectedUIContext.customAccountDetails || [];
-    const FirstCustomPage: ComponentType<AccountDetailsFormProps> | null =
+    const FirstCustomPage: ComponentType<AccountDetailsFormMobileProps> | null =
         customDetails.length > 0 && customDetails[0] ? customDetails[0].component : null;
     const RegistrationPages: RegistrationPage[] = [
         {

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -50,7 +50,7 @@ import {
     useRegistrationUIState,
     CustomAccountDetails,
     CustomRegistrationForm,
-    AccountDetailsFormProps,
+    AccountDetailsFormMobileProps,
 } from '@brightlayer-ui/react-auth-shared';
 import { CustomRegistrationDetailsGroup, RegistrationPage } from '../types';
 import { Instruction } from '../components/Instruction';
@@ -239,7 +239,7 @@ export const SelfRegistrationPager: React.FC<SelfRegistrationPagerProps> = (prop
 
     // Page Definitions
     const customDetails = injectedUIContext.customAccountDetails || [];
-    const FirstCustomPage: ComponentType<AccountDetailsFormProps> | null =
+    const FirstCustomPage: ComponentType<AccountDetailsFormMobileProps> | null =
         customDetails.length > 0 && customDetails[0] ? customDetails[0].component : null;
     const RegistrationPages: RegistrationPage[] = [
         {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes: auth-shared was importing a react-native module into types that were being imported into our react workflows. We need these separated so that react projects don't have a peer dependency on react native. This is the work done on the react native side to reflect those udpates. 

This may be a breaking change, so I'll likely be updating the changelog and version number. Regardless, I could use this alpha package publish just to test things more easily for the upcoming PR's to officially publish.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use new AccountDetailsFormMobileProps type from shared-auth

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Make sure the account details navigation via keyboard next buttons continues to work during the registration process using the react auth shared branch `bug/fix-missing-type-definition-for-react-native`
